### PR TITLE
Add support for mimetype and headers

### DIFF
--- a/modules/oauth.py
+++ b/modules/oauth.py
@@ -82,7 +82,7 @@ class OAuth:
 			return False
 
 		if result is not None and destination is not None:
-			ret = {'status' : result.status_code, 'content' : None}
+			ret = {'status' : result.status_code, 'content' : None, 'mimetype' : result.headers['Content-Type'], 'headers' : result.headers}
 			try:
 				with open(destination, 'wb') as handle:
 					for chunk in result.iter_content(chunk_size=512):
@@ -94,9 +94,9 @@ class OAuth:
 			return ret
 		else:
 			if result is None:
-				return {'status':500, 'content':'Unable to download URL using OAuth'}
+				return {'status':500, 'content':'Unable to download URL using OAuth', 'mimetype': None, 'headers': None}
 			else:
-				return {'status':result.status_code, 'content':result.content}
+				return {'status':result.status_code, 'content':result.content, 'mimetype' : result.headers['Content-Type'], 'headers' : result.headers}
 
 	def getRedirectId(self):
 		r = requests.get('%s/?register' % self.ridURI)

--- a/services/base.py
+++ b/services/base.py
@@ -340,9 +340,16 @@ class BaseService:
         r = requests.get(url, params=params)
 
       result['status'] = r.status_code
+      result['mimetype'] = None
+      result['headers'] = r.headers
+
+      if 'Content-Type' in r.headers:
+        result['mimetype'] = r.headers['Content-Type']
+
       if destination is None:
         result['content'] = r.content
       else:
+        result['content'] = None
         with open(destination, 'wb') as f:
           for chunk in r.iter_content(chunk_size=1024):
             f.write(chunk)


### PR DESCRIPTION
The requestUrl function didn't provide mimetype to caller which
made it hard to use. Now it has mimetype but you can also access
the headers that were returned if that is needed.